### PR TITLE
train L independently

### DIFF
--- a/scripts/burgers/pcno_burgers_test.py
+++ b/scripts/burgers/pcno_burgers_test.py
@@ -108,14 +108,14 @@ model = PCNO(ndim, modes, nmeasures=1,
                layers=[128,128,128,128,128],
                fc_dim=128,
                in_dim=x_train.shape[-1], out_dim=y_train.shape[-1],
-               train_sp_L="together",
+               train_sp_L="independently",
                act='gelu').to(device)
 
 
 
 epochs = 5000
 base_lr = 2e-4 #0.001
-lr_ratio = 10
+lr_ratio = 0.1
 scheduler = "OneCycleLR"
 weight_decay = 1.0e-4
 batch_size= 8

--- a/scripts/darcy_square/pcno_darcy_test.py
+++ b/scripts/darcy_square/pcno_darcy_test.py
@@ -110,7 +110,7 @@ model = PCNO(ndim, modes, nmeasures=1,
                layers=[128,128,128,128,128],
                fc_dim=128,
                in_dim=x_train.shape[-1], out_dim=y_train.shape[-1],
-               train_sp_L="together",
+               train_sp_L="independently",
                act='gelu').to(device)
 
 


### PR DESCRIPTION
Training L independently has better performance.

### Burgers
train L independently with `lr_ratio` equals to 0.1
| **Resolution** | **Together** | **Independently** |
| :---------------: | :-------------: | :------------------: |
| 2048 | 0.0005606363143306225 | 0.0005171928339404986 |
| 1024 | 0.000579124060459435  | 0.000578167662024498 |
| 512   | 0.0006341511930804699 | 0.0005870205338578671 |
| 256   | 0.0007481357885990292 | 0.0007013014028780162 |
### Darcy
train L independently with `lr_ratio` equals to 10
| **Resolution** | **Together** | **Independently** |
| :---------------: | :-------------: | :------------------: |
| 211 | 0.0050999702978879215 | 0.004787901369854808 |
| 141 | 0.005574966911226511  | 0.005227762181311846 |
| 85   | 0.00681828884407878 | 0.006227938737720251 |


